### PR TITLE
Function for plotting a graph as simply as possible.

### DIFF
--- a/src/Diagrams/TwoD/GraphViz.hs
+++ b/src/Diagrams/TwoD/GraphViz.hs
@@ -254,12 +254,12 @@ simpleGraphDiagram layoutCmd gr = do
       edgeLengths = [ (fromJust $ M.lookup i vmap) `distance` (fromJust $ M.lookup j vmap)
                     | (i, j, _) <- G.labEdges gr'
                     ]
-      radius = minimum edgeLengths / 4
+      nodeRadius = minimum edgeLengths / 4
       drawing = drawGraph
-                     (const $ place (circle radius))
-                     (\_ p1 _ p2 _ p -> arrowBetween' (opts p) p1 p2)
+                     (const $ place (circle nodeRadius))
+                     (\_ p₁ _ p₂ _ p -> arrowBetween' (opts p) p₁ p₂)
                      gr'
-      opts p = with & gaps .~ local radius
+      opts p = with & gaps .~ local nodeRadius
                     & arrowShaft .~ (unLoc . head $ pathTrails p)
-                    & headLength .~ local radius
+                    & headLength .~ local nodeRadius
   return drawing


### PR DESCRIPTION
While this library shines most when you actually use diagrams' capabilities to freely draw node designs, this is a bit overkill when one merely wants to visualise some topology. I wrote a simple function that just takes an unannotated graph and outputs a diagram with circles for nodes and correct spacings, arrow-head lengths etc..

The name and exact signature is of course debatable.
